### PR TITLE
Fixes for Haxe 4

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -8,8 +8,7 @@
   "classPath": "source/",
   "releasenote": "2018 Improved Release",
   "contributors": ["JohnDimi"],
-  "dependencies":
-  {
-    "flixel": "4.3.0"
+  "dependencies": {
+    "flixel": ""
   }
 }

--- a/source/djFlixel/gfx/GfxTool.hx
+++ b/source/djFlixel/gfx/GfxTool.hx
@@ -152,14 +152,14 @@ class GfxTool
 	 */
 	public static function stitchBitmaps(ar:Array<BitmapData>):BitmapData
 	{
-		var final:BitmapData = new BitmapData((ar.length * ar[0].width), ar[0].height, true, 0x00000000);
+		var f:BitmapData = new BitmapData((ar.length * ar[0].width), ar[0].height, true, 0x00000000);
 		var rect = new Rectangle(0, 0, ar[0].width, ar[0].height);
 		var p = new Point(0, 0);
 		for (i in 0...ar.length) {
-			final.copyPixels(ar[i], rect, p);
+			f.copyPixels(ar[i], rect, p);
 			p.x += ar[i].width;
 		}
-		return final;
+		return f;
 	}//---------------------------------------------------;
 		
 	/**

--- a/source/djFlixel/gui/list/VListBase.hx
+++ b/source/djFlixel/gui/list/VListBase.hx
@@ -33,8 +33,11 @@ import flixel.util.FlxDestroyUtil;
  * K: Type of Child Data
  * 
  */
-
+#if (haxe_ver >= "4.0.0")
+class VListBase<T:IListItem<K> & FlxSprite, K> extends FlxGroup
+#else
 class VListBase<T:(IListItem<K>,FlxSprite),K> extends FlxGroup
+#end
 {	
 	
 	// -- Some Static Defaults ::

--- a/source/djFlixel/gui/list/VListNav.hx
+++ b/source/djFlixel/gui/list/VListNav.hx
@@ -22,7 +22,11 @@ import flixel.tweens.misc.VarTween;
  *  new VListNav<GraphicElement,DataElement>
  * 
  */
+#if (haxe_ver >= "4.0.0")
+class VListNav<T:IListItem<K> & FlxSprite,K> extends VListBase<T,K>
+#else
 class VListNav<T:(IListItem<K>,FlxSprite),K> extends VListBase<T,K>
+#end
 {
 	// When animating the cursor start from this alpha to 1
 	static inline var CURSOR_START_ALPHA:Float = 0.5;


### PR DESCRIPTION
Adds a few changes necessary to getting this library running with Haxe 4. It also shouldn't break anything for older versions of Haxe.

* Setting the required `flixel` version was causing dependency issues with Haxelib, so I removed the `4.3.0` requirement in the `haxelib.json`
* Haxe 4 added in a `final` keyword, so that became a reserved name. This caused an issue with the `var final` in `GfxTool.hx`
* Haxe 4 has some syntax changes for Type constraints, as seen in `VListNav.hx` and `VListBase.hx`